### PR TITLE
Fixed crash

### DIFF
--- a/GA-TB-Reference-Guide/ViewControllers/SearchViewController.swift
+++ b/GA-TB-Reference-Guide/ViewControllers/SearchViewController.swift
@@ -251,7 +251,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDe
             webViewViewController.titlelabel = Array(chapterIndex.chapterNested.joined())[subArrayPointer]
             webViewViewController.navTitle = navTitle
             webViewViewController.comingFromSearch = true
-            webViewViewController.searchTerm = search.text
+            webViewViewController.searchTerm = search.text != "" ? search.text : nil
             webViewViewController.uniqueAddress = Array(chapterIndex.chapterCode.joined())[subArrayPointer]
         }
     }


### PR DESCRIPTION
Declared searchTerm variable as nil when user passes empty string;

Javascript injection of the searchTerm highlight was creating a crash when the user didn't specify any searchTerm. I've added code to the SearchVC to pass a nil value for searchTerm when the query is empty.
`webViewViewController.searchTerm = search.text != "" ? search.text : nil`

This prevents 
`if let searchTerm = searchTerm, comingFromSearch, !searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty{
            searchView.isHidden = searchTerm.isEmpty
            searchTermView.text = searchTerm
        } else {
            searchView.isHidden = true
        }
` 

And 
`if let searchTerm = searchTerm {
                highlightSearch(term: searchTerm)
            }
`

From firing an observer value here
`webView.addObserver(self, forKeyPath: "URL", options: [.new, .old], context: nil)`'
When the JS gets injected through the highlightSearch() function